### PR TITLE
Avoid requiring .from_pretrained when loading (closes #15)

### DIFF
--- a/examples/init_model.py
+++ b/examples/init_model.py
@@ -23,6 +23,9 @@ def main(path, name="bert-base-uncased", lang="en"):
     msg.good(f"Saved '{name}' ({lang})")
     msg.text(f"Pipeline: {nlp.pipe_names}")
     msg.text(f"Location: {path}")
+    with msg.loading("Verifying model loads..."):
+        loaded = nlp.from_disk(path)
+    msg.good("Model loads!")
 
 
 if __name__ == "__main__":

--- a/spacy_pytorch_transformers/__init__.py
+++ b/spacy_pytorch_transformers/__init__.py
@@ -2,7 +2,7 @@ from .language import PyTT_Language
 from .tok2vec import PyTT_TokenVectorEncoder  # noqa
 from .pipeline import PyTT_TextCategorizer  # noqa
 from .wordpiecer import PyTT_WordPiecer  # noqa
-from .model_registry import register_model, get_model_function # noqa
+from .model_registry import register_model, get_model_function  # noqa
 from .about import __version__  # noqa
 
 PyTT_Language.install_extensions()

--- a/spacy_pytorch_transformers/model_registry.py
+++ b/spacy_pytorch_transformers/model_registry.py
@@ -1,7 +1,6 @@
 from thinc.api import layerize, chain, flatten_add_lengths, with_getitem
-from thinc.t2v import Pooling, mean_pool, sum_pool, max_pool
-from thinc.v2v import Softmax, Affine, Model, Maxout
-from thinc.misc import LayerNorm
+from thinc.t2v import Pooling, mean_pool
+from thinc.v2v import Softmax, Affine, Model
 from thinc.neural.util import get_array_module
 
 
@@ -40,13 +39,14 @@ def fine_tune_class_vector(nr_class, *, exclusive_classes=True, **cfg):
     return chain(
         get_pytt_class_tokens,
         flatten_add_lengths,
-        with_getitem(0, chain(
-                Affine(cfg["token_vector_width"], cfg["token_vector_width"]),
-                tanh)),
+        with_getitem(
+            0, chain(Affine(cfg["token_vector_width"], cfg["token_vector_width"]), tanh)
+        ),
         Pooling(mean_pool),
         Affine(2, cfg["token_vector_width"], drop_factor=0),
-        softmax
+        softmax,
     )
+
 
 @register_model("fine_tune_pooler_output")
 def fine_tune_pooler_output(nr_class, *, exclusive_classes=True, **cfg):
@@ -141,21 +141,25 @@ def get_pytt_last_hidden(docs, drop=0.0):
 
 
 @layerize
-def softmax(X, drop=0.):
+def softmax(X, drop=0.0):
     ops = Model.ops
     Y = ops.softmax(X)
+
     def backprop_softmax(dY, sgd=None):
         dX = ops.backprop_softmax(Y, dY)
         return dX
+
     return Y, backprop_softmax
 
 
 @layerize
-def tanh(X, drop=0.):
+def tanh(X, drop=0.0):
     xp = get_array_module(X)
     Y = xp.tanh(X)
+
     def backprop_tanh(dY, sgd=None):
         one = Y.dtype.type(1)
-        dX = dY * (1 - Y * Y)
+        dX = dY * (one - Y * Y)
         return dX
+
     return Y, backprop_tanh

--- a/spacy_pytorch_transformers/tok2vec.py
+++ b/spacy_pytorch_transformers/tok2vec.py
@@ -7,6 +7,7 @@ from spacy.util import minibatch
 from spacy.tokens import Doc, Span
 
 from .wrapper import PyTT_Wrapper
+from .util import get_pytt_config, get_pytt_model
 from .util import batch_by_length, pad_batch, flatten_list, unflatten_list, Activations
 from .util import pad_batch_activations
 from .util import Array, Optimizer, Dropout
@@ -39,9 +40,9 @@ class PyTT_TokenVectorEncoder(Pipe):
         name (unicode): Name of pre-trained model, e.g. 'bert-base-uncased'.
         RETURNS (PyTT_TokenVectorEncoder): The token vector encoder.
         """
-        cfg["from_pretrained"] = True
         cfg["pytt_name"] = name
-        model = cls.Model(**cfg)
+        model = cls.Model(from_pretrained=True, **cfg)
+        cfg["pytt_config"] = dict(model._model._model.config.to_dict())
         self = cls(vocab, model=model, **cfg)
         return self
 
@@ -59,7 +60,10 @@ class PyTT_TokenVectorEncoder(Pipe):
         if cfg.get("from_pretrained"):
             pytt_model = PyTT_Wrapper.from_pretrained(name)
         else:
-            pytt_model = PyTT_Wrapper(name)
+            config_cls = get_pytt_config(name)
+            model_cls = get_pytt_model(name)
+            model = model_cls(config_cls(**config))
+            pytt_model = PyTT_Wrapper(name, cfg["pytt_config"], model)
         nO = pytt_model.nO
         batch_by_length = cfg.get("words_per_batch", 3000)
         max_length = cfg.get("max_length", 512)

--- a/spacy_pytorch_transformers/tok2vec.py
+++ b/spacy_pytorch_transformers/tok2vec.py
@@ -62,7 +62,7 @@ class PyTT_TokenVectorEncoder(Pipe):
         else:
             config_cls = get_pytt_config(name)
             model_cls = get_pytt_model(name)
-            model = model_cls(config_cls(**config))
+            model = model_cls(config_cls(**cfg["pytt_config"]))
             pytt_model = PyTT_Wrapper(name, cfg["pytt_config"], model)
         nO = pytt_model.nO
         batch_by_length = cfg.get("words_per_batch", 3000)

--- a/spacy_pytorch_transformers/tok2vec.py
+++ b/spacy_pytorch_transformers/tok2vec.py
@@ -42,7 +42,7 @@ class PyTT_TokenVectorEncoder(Pipe):
         """
         cfg["pytt_name"] = name
         model = cls.Model(from_pretrained=True, **cfg)
-        cfg["pytt_config"] = dict(model._model._model.config.to_dict())
+        cfg["pytt_config"] = dict(model._model.pytt_model.config.to_dict())
         self = cls(vocab, model=model, **cfg)
         return self
 
@@ -60,6 +60,10 @@ class PyTT_TokenVectorEncoder(Pipe):
         if cfg.get("from_pretrained"):
             pytt_model = PyTT_Wrapper.from_pretrained(name)
         else:
+            # Work around floating point limitation in ujson:
+            # If we have the setting cfg["pytt_config"]["layer_norm_eps"] as 0,
+            # that's because of misprecision in serializing. Fix that.
+            cfg["pytt_config"]["layer_norm_eps"] = 1e-12
             config_cls = get_pytt_config(name)
             model_cls = get_pytt_model(name)
             model = model_cls(config_cls(**cfg["pytt_config"]))

--- a/spacy_pytorch_transformers/tok2vec.py
+++ b/spacy_pytorch_transformers/tok2vec.py
@@ -94,6 +94,10 @@ class PyTT_TokenVectorEncoder(Pipe):
     def token_vector_width(self):
         return self.model._model.nO
 
+    @property
+    def pytt_model(self):
+        return self.model._model.pytt_model
+
     def __call__(self, doc):
         """Process a Doc and assign the extracted features.
 

--- a/spacy_pytorch_transformers/util.py
+++ b/spacy_pytorch_transformers/util.py
@@ -75,7 +75,7 @@ class Activations:
         # Transpose the lists, so that the inner list items refer
         # to the subsequences. Then we can vstack those.
         ah = list(map(xp.vstack, zip(*[x.ah for x in sub_acts])))
-        #aa = list(map(xp.vstack, zip(*[x.aa for x in sub_acts])))
+        # aa = list(map(xp.vstack, zip(*[x.aa for x in sub_acts])))
         aa = []
         return cls(lh, po, ah, aa, is_grad=sub_acts[0].is_grad)
 
@@ -169,7 +169,7 @@ def get_pytt_tokenizer(name):
         raise ValueError(f"Unsupported PyTT config name: '{name}'")
 
 
-def pad_batch(batch: List[Array], *, xp=numpy, to: int=0) -> Array:
+def pad_batch(batch: List[Array], *, xp=numpy, to: int = 0) -> Array:
     """Pad a batch with zeros so that sequences are the same length, and form
     them into a single array.
     """
@@ -191,7 +191,7 @@ def pad_batch(batch: List[Array], *, xp=numpy, to: int=0) -> Array:
     return xp.vstack(padded)
 
 
-def pad_batch_activations(batch: List[Activations], *, to: int=0) -> Activations:
+def pad_batch_activations(batch: List[Activations], *, to: int = 0) -> Activations:
     if not batch:
         return Activations.blank()
     xp = get_array_module(batch[0])

--- a/spacy_pytorch_transformers/wrapper.py
+++ b/spacy_pytorch_transformers/wrapper.py
@@ -81,7 +81,6 @@ class PyTT_Wrapper(PyTorchWrapper):
         model_kwargs = self.get_model_kwargs(ids)
         self._model.train()
         y_var = self._model(ids, **model_kwargs)
-        self._model.training = is_training
         output = Activations.from_pytt(y_var, is_grad=False)
         assert output.lh is not None
 

--- a/spacy_pytorch_transformers/wrapper.py
+++ b/spacy_pytorch_transformers/wrapper.py
@@ -104,12 +104,12 @@ class PyTT_Wrapper(PyTorchWrapper):
                         self._optimizer = self._create_optimizer(sgd)
 
                     if getattr(self, "_lr_schedule", None) is None:
-                        self._lr_schedule = WarmupLinearSchedule(self._optimizer,
-                            warmup_steps=50, t_total=500)
+                        self._lr_schedule = WarmupLinearSchedule(
+                            self._optimizer, warmup_steps=50, t_total=500
+                        )
                     if sgd.max_grad_norm:
                         torch.nn.utils.clip_grad.clip_grad_norm_(
-                            self._model.parameters(),
-                            sgd.max_grad_norm 
+                            self._model.parameters(), sgd.max_grad_norm
                         )
                     optimizer = self._optimizer
                     self._lr_schedule.step()
@@ -131,9 +131,7 @@ class PyTT_Wrapper(PyTorchWrapper):
 
     def _create_optimizer(self, sgd):
         optimizer = AdamW(
-            self._model.parameters(),
-            lr=sgd.alpha,
-            betas=(sgd.b1, sgd.b2),
+            self._model.parameters(), lr=sgd.alpha, betas=(sgd.b1, sgd.b2)
         )
 
         return optimizer

--- a/spacy_pytorch_transformers/wrapper.py
+++ b/spacy_pytorch_transformers/wrapper.py
@@ -38,7 +38,21 @@ class PyTT_Wrapper(PyTorchWrapper):
 
     @property
     def nO(self):
-        return self.cfg["hidden_size"]
+        if "hidden_size" in self.cfg:
+            # BERT
+            return self.cfg["hidden_size"]
+        elif "n_embd" in self.cfg:
+            # GPT2
+            return self.cfg["n_embd"]
+        elif "d_model" in self.cfg:
+            # XLNet
+            return self.cfg["d_model"]
+        elif hasattr(self.pytt_model, "dim"):
+            # XLM
+            return self.pytt_model.dim
+        else:
+            keys = ", ".join(self.cfg.keys())
+            raise ValueError(f"Unexpected config. Keys: {keys}")
 
     @property
     def pytt_model(self):

--- a/spacy_pytorch_transformers/wrapper.py
+++ b/spacy_pytorch_transformers/wrapper.py
@@ -65,11 +65,9 @@ class PyTT_Wrapper(PyTorchWrapper):
     def predict(self, ids: Array):
         ids = torch.as_tensor(ids, dtype=torch.int64)
         model_kwargs = self.get_model_kwargs(ids)
-        is_training = self._model.training
-        self._model.training = False
+        self._model.eval()
         with torch.no_grad():
             y_var = self._model(ids, **model_kwargs)
-        self._model.training = is_training
         return Activations.from_pytt(y_var, is_grad=False)
 
     def begin_update(
@@ -80,7 +78,6 @@ class PyTT_Wrapper(PyTorchWrapper):
             # Thinc's API I'm least happy with...
             return self.predict(ids), lambda dY, sgd=None: None
         ids = torch.as_tensor(ids, dtype=torch.int64)
-        is_training = self._model.training
         model_kwargs = self.get_model_kwargs(ids)
         self._model.train()
         y_var = self._model(ids, **model_kwargs)
@@ -121,6 +118,7 @@ class PyTT_Wrapper(PyTorchWrapper):
                     optimizer.zero_grad()
             return None
 
+        self._model.eval()
         return output, backward_pytorch
 
     def get_model_kwargs(self, ids):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from spacy_pytorch_transformers import PyTT_Language, PyTT_WordPiecer
 from spacy_pytorch_transformers import PyTT_TokenVectorEncoder
 
-MODEL_NAMES = ["bert-base-uncased", "gpt2", "xlnet-base-cased", "xlm-mlm-enfr-1024"]
+MODEL_NAMES = ["bert-base-uncased", "gpt2", "xlnet-base-cased"]
 
 
 @pytest.fixture(scope="session", params=MODEL_NAMES)


### PR DESCRIPTION
This should avoid the bug in #15, where our model packages still ended up calling into PyTT's `.from_pretrained()` methods, which would fetch data from the S3 bucket unnecessarily.

The bug was introduced because the `PyTT_TokenVectorEncoder` had the `from_pretrained` config value set to `True`. This masked a further bug in the `PyTT_Wrapper`: the code-path where the wrapper should be created without the `.from_pretrained()` was never exercised.

To fix this, we need to store the config values from the PyTT config classes like `BertConfig` in the `PyTT_TokenVectorEncoder` component's `.cfg` dictionary. I've put these in under `pytt_config`. When we want to create a blank model, we instantiate one of the config classes such as `BertConfig`, and instantiate the model class such as `BertModel`. This lets us create the `PyTT_Wrapper` object, so that we can then deserialise into it.