### PR TITLE
Improve optimisation

### DIFF
--- a/examples/tasks/glue.conf
+++ b/examples/tasks/glue.conf
@@ -19,7 +19,7 @@ eval_batch_size = 32
 learning_rate = 1e-5
 
 # Weight decay (aka L2 penalty)
-weight_decay = 0.
+weight_decay = 0.005
 
 # Epsilon for the Adam optimizer
 adam_epsilon = 1e-8
@@ -34,7 +34,7 @@ use_learn_rate_schedule = 1
 lr_range = 2
 
 # How many epochs to set as the period cycle for the cyclic learning rate.
-lr_period = 3
+lr_period = 2
 
 # Whether to use stochastic weight averaging
 use_swa = 1
@@ -46,7 +46,7 @@ seed = 0
 eval_every = 100
 
 # How many checkpoints to elapse without improvement before stopping
-patience = 3
+patience = 10
 
 # Unused values
 num_train_epochs = -1

--- a/examples/tasks/glue.conf
+++ b/examples/tasks/glue.conf
@@ -27,17 +27,14 @@ adam_epsilon = 1e-8
 # Max gradient norm (aka gradient clipping)
 max_grad_norm = 1.0
 
-# Number of training epochs to perform
-num_train_epochs = 10
-
-# Total number of training iterations to perform. If set, overrides num_train_epochs
-max_steps = -1
-
-# Linear warmup of learning rate over warmup_steps
-warmup_steps = 0
-
 # Whether to use the learning rate schedule (or keep LR fixed)
 use_learn_rate_schedule = 1
+
+# How wide to make the triangular LR cycle. From lr/lr_range to lr*lr_range.
+lr_range = 3
+
+# How many epochs to set as the period cycle for the cyclic learning rate.
+lr_period = 2
 
 # Whether to use stochastic weight averaging
 use_swa = 1
@@ -47,3 +44,11 @@ seed = 0
 
 # How often (by steps) to evaluate
 eval_every = 100
+
+# How many checkpoints to elapse without improvement before stopping
+patience = 3
+
+# Unused values
+num_train_epochs = -1
+max_steps = -1
+warmup_steps = -1

--- a/examples/tasks/glue.conf
+++ b/examples/tasks/glue.conf
@@ -19,7 +19,7 @@ eval_batch_size = 32
 learning_rate = 2e-5
 
 # Weight decay (aka L2 penalty)
-weight_decay = 0.0
+weight_decay = 0.01
 
 # Epsilon for the Adam optimizer
 adam_epsilon = 1e-8
@@ -28,7 +28,7 @@ adam_epsilon = 1e-8
 max_grad_norm = 1.0
 
 # Number of training epochs to perform
-num_train_epochs = 3
+num_train_epochs = 10
 
 # Total number of training iterations to perform. If set, overrides num_train_epochs
 max_steps = -1
@@ -37,7 +37,7 @@ max_steps = -1
 warmup_steps = 0
 
 # Whether to use the learning rate schedule (or keep LR fixed)
-use_learn_rate_schedule = 0
+use_learn_rate_schedule = 1
 
 # Whether to use stochastic weight averaging
 use_swa = 0

--- a/examples/tasks/glue.conf
+++ b/examples/tasks/glue.conf
@@ -40,7 +40,7 @@ warmup_steps = 0
 use_learn_rate_schedule = 1
 
 # Whether to use stochastic weight averaging
-use_swa = 0
+use_swa = 1
 
 # Set random seed
 seed = 0

--- a/examples/tasks/glue.conf
+++ b/examples/tasks/glue.conf
@@ -31,7 +31,7 @@ max_grad_norm = 1.0
 use_learn_rate_schedule = 1
 
 # How wide to make the triangular LR cycle. From lr/lr_range to lr*lr_range.
-lr_range = 3
+lr_range = 4
 
 # How many epochs to set as the period cycle for the cyclic learning rate.
 lr_period = 2

--- a/examples/tasks/glue.conf
+++ b/examples/tasks/glue.conf
@@ -16,10 +16,10 @@ batch_size = 32
 eval_batch_size = 32
 
 # The initial learning rate for Adam
-learning_rate = 2e-5
+learning_rate = 1e-5
 
 # Weight decay (aka L2 penalty)
-weight_decay = 0.01
+weight_decay = 0.
 
 # Epsilon for the Adam optimizer
 adam_epsilon = 1e-8
@@ -31,10 +31,10 @@ max_grad_norm = 1.0
 use_learn_rate_schedule = 1
 
 # How wide to make the triangular LR cycle. From lr/lr_range to lr*lr_range.
-lr_range = 4
+lr_range = 2
 
 # How many epochs to set as the period cycle for the cyclic learning rate.
-lr_period = 2
+lr_period = 3
 
 # Whether to use stochastic weight averaging
 use_swa = 1

--- a/examples/tasks/run_glue.py
+++ b/examples/tasks/run_glue.py
@@ -12,8 +12,7 @@ from collections import Counter
 from pathlib import Path
 from spacy.util import minibatch
 
-from spacy_pytorch_transformers.util import warmup_linear_rates
-from spacy_pytorch_transformers.util import slanted_triangular_rate
+from spacy_pytorch_transformers.util import cyclic_triangular_rate
 from spacy_pytorch_transformers.hyper_params import get_hyper_params
 
 from glue_util import read_train_data, read_dev_data
@@ -169,7 +168,7 @@ def main(
     msg.row(["#", "Loss", "Score"], widths=table_widths)
     msg.row(["-" * width for width in table_widths])
     # Set up learning rate schedule
-    learn_rates = slanted_triangular_rate(
+    learn_rates = cyclic_triangular_rate(
         HP.learning_rate / HP.lr_range, HP.learning_rate * HP.lr_range,
         nr_batch * HP.lr_period)
     optimizer.pytt_lr = next(learn_rates)

--- a/examples/tasks/run_glue.py
+++ b/examples/tasks/run_glue.py
@@ -206,16 +206,17 @@ def main(
             step += 1
         epoch += 1
         # Stop if no improvement in HP.patience checkpoints
-        best_score, best_step, best_epoch = max(results)
-        if ((step - best_step) // HP.eval_every) >= HP.patience:
-            break
+        if results:
+            best_score, best_step, best_epoch = max(results)
+            if ((step - best_step) // HP.eval_every) >= HP.patience:
+                break
 
-    table_widths = [2, 4, 4]
+    table_widths = [2, 4, 6]
     msg.info(f"Best scoring checkpoints")
     msg.row(["Epoch", "Step", "Score"], widths=table_widths)
     msg.row(["-" * width for width in table_widths])
     for score, step, epoch in sorted(results, reverse=True)[:10]:
-        msg.row([epoch, step, "%.2f" % score], widths=table_widths)
+        msg.row([epoch, step, "%.2f" % (score*100)], widths=table_widths)
 
 
 if __name__ == "__main__":

--- a/examples/train_textcat.py
+++ b/examples/train_textcat.py
@@ -4,13 +4,15 @@ import re
 import random
 import json
 from pathlib import Path
+from collections import Counter
 import thinc.extra.datasets
 import spacy
 import torch
 from spacy.util import minibatch
 import tqdm
 import unicodedata
-from spacy_pytorch_transformers.util import warmup_linear_rates
+import wasabi
+from spacy_pytorch_transformers.util import cyclic_triangular_rate
 
 
 @plac.annotations(
@@ -89,33 +91,58 @@ def main(
     # Initialize the TextCategorizer, and create an optimizer.
     optimizer = nlp.resume_training()
     optimizer.alpha = 0.001
-    learn_rates = warmup_linear_rates(
-        learn_rate, 0, n_iter * len(train_data) // batch_size
-    )
+    optimizer.pytt_weight_decay = 0.005
+    optimizer.L2 = 0.0
+    learn_rates = cyclic_triangular_rate(learn_rate / 3, learn_rate * 3,
+        2 * len(train_data) // batch_size)
     print("Training the model...")
     print("{:^5}\t{:^5}\t{:^5}\t{:^5}".format("LOSS", "P", "R", "F"))
-    for i in range(n_iter):
-        losses = {}
-        # batch up the examples using spaCy's minibatch
+
+    pbar = tqdm.tqdm(total=100, leave=False)
+    results = []
+    epoch = 0
+    step = 0
+    eval_every = 100
+    patience = 3
+    while True:
+        # Train and evaluate
+        losses = Counter()
         random.shuffle(train_data)
         batches = minibatch(train_data, size=batch_size)
-        with tqdm.tqdm(total=total_words, leave=False) as pbar:
-            for batch in batches:
-                optimizer.pytt_lr = next(learn_rates)
-                texts, annotations = zip(*batch)
-                nlp.update(texts, annotations, sgd=optimizer, drop=0.1, losses=losses)
-                pbar.update(sum(len(text.split()) for text in texts))
-        # evaluate on the dev data split off in load_data()
-        with nlp.use_params(optimizer.averages):
-            scores = evaluate(nlp, eval_texts, eval_cats)
-        print(
-            "{0:.3f}\t{1:.3f}\t{2:.3f}\t{3:.3f}".format(
-                losses["pytt_textcat"],
-                scores["textcat_p"],
-                scores["textcat_r"],
-                scores["textcat_f"],
-            )
-        )
+        for batch in batches:
+            optimizer.pytt_lr = next(learn_rates)
+            texts, annotations = zip(*batch)
+            nlp.update(texts, annotations, sgd=optimizer, drop=0.1, losses=losses)
+            pbar.update(1)
+            if step and (step % eval_every) == 0:
+                pbar.close()
+                with nlp.use_params(optimizer.averages):
+                    scores = evaluate(nlp, eval_texts, eval_cats)
+                results.append((scores["textcat_f"], step, epoch))
+                print(
+                    "{0:.3f}\t{1:.3f}\t{2:.3f}\t{3:.3f}".format(
+                        losses["pytt_textcat"],
+                        scores["textcat_p"],
+                        scores["textcat_r"],
+                        scores["textcat_f"],
+                    )
+                )
+                pbar = tqdm.tqdm(total=eval_every, leave=False)
+            step += 1
+        epoch += 1
+        # Stop if no improvement in HP.patience checkpoints
+        if results:
+            best_score, best_step, best_epoch = max(results)
+            if ((step - best_step) // eval_every) >= patience:
+                break
+
+    msg = wasabi.Printer()
+    table_widths = [2, 4, 6]
+    msg.info(f"Best scoring checkpoints")
+    msg.row(["Epoch", "Step", "Score"], widths=table_widths)
+    msg.row(["-" * width for width in table_widths])
+    for score, step, epoch in sorted(results, reverse=True)[:10]:
+        msg.row([epoch, step, "%.2f" % (score*100)], widths=table_widths)
 
     # Test the trained model
     test_text = "This movie sucked"

--- a/spacy_pytorch_transformers/hyper_params.py
+++ b/spacy_pytorch_transformers/hyper_params.py
@@ -7,6 +7,8 @@ FIELDS = dict(
     batch_size=int,
     eval_batch_size=int,
     learning_rate=float,
+    lr_range=float,
+    lr_period=int,
     weight_decay=float,
     adam_epsilon=float,
     max_grad_norm=float,
@@ -18,6 +20,7 @@ FIELDS = dict(
     eval_every=int,
     use_learn_rate_schedule=int,
     use_swa=int,
+    patience=int,
 )
 
 

--- a/spacy_pytorch_transformers/model_registry.py
+++ b/spacy_pytorch_transformers/model_registry.py
@@ -64,7 +64,7 @@ def softmax_tanh_class_vector(nr_class, *, exclusive_classes=True, **cfg):
         flatten_add_lengths,
         with_getitem(0, chain(Affine(width, width), tanh)),
         Pooling(mean_pool),
-        Softmax(2, width),
+        Softmax(nr_class, width),
     )
 
 
@@ -80,7 +80,7 @@ def softmax_class_vector(nr_class, *, exclusive_classes=True, **cfg):
         get_pytt_class_tokens,
         flatten_add_lengths,
         Pooling(mean_pool),
-        Softmax(2, width),
+        Softmax(nr_class, width),
     )
 
 

--- a/spacy_pytorch_transformers/util.py
+++ b/spacy_pytorch_transformers/util.py
@@ -342,7 +342,7 @@ def warmup_linear_rates(initial_rate, warmup_steps, total_steps):
         step += 1
 
 
-def slanted_triangular_rate(min_lr, max_lr, period):
+def cyclic_triangular_rate(min_lr, max_lr, period):
     it = 1
     while True:
         # https://towardsdatascience.com/adaptive-and-cyclical-learning-rates-using-pytorch-2bf904d18dee

--- a/spacy_pytorch_transformers/util.py
+++ b/spacy_pytorch_transformers/util.py
@@ -342,4 +342,15 @@ def warmup_linear_rates(initial_rate, warmup_steps, total_steps):
         step += 1
 
 
+def slanted_triangular_rate(min_lr, max_lr, period):
+    it = 1
+    while True:
+        # https://towardsdatascience.com/adaptive-and-cyclical-learning-rates-using-pytorch-2bf904d18dee
+        cycle = numpy.floor(1 + it / (2 * period))
+        x = numpy.abs(it / period - 2 * cycle + 1)
+        relative = max(0, 1-x)
+        yield min_lr + (max_lr - min_lr) * relative
+        it += 1
+
+
 from .activations import Activations  # noqa


### PR DESCRIPTION
Previously I had explored using stochastic weight averaging, as implemented in the `torchcontrib` module. spaCy has always used averaged parameters, from day 0: at first we used the averaged perceptron, and our neural network models have always used the EMA averaging scheme from the SyntaxNet paper.

This PR replaces the torchcontrib SWA averaging, and instead lets Thinc manage the parameter averaging for the PyTorch models. This has been performing much more reliably, and introduces no new hyper-parameters. We also get to use the `use_params()` method, so that the weight averaging works identically to all other Thinc models.

In addition to the averaging, I've implemented cyclic learning rates, and updated the Glue and train_textcat.py scripts to use them. This takes away one of the previous hyper-parameters: we no longer have to specify the number of epochs. Instead we just let the script run, and let the early stopping halt it when the score has stopped improving.

The goal is to replace as many hyper-parameters as possible with configurations that work reliably out of the box. I want to produce a full Glue run with reasonable results using a single hyper-parameter configuration.

Here's how the weight averaging from Thinc works:

```
    def update_averages(self, ema, weights, t, max_decay=0.9999):
        cdef weight_t decay = (1.0 + t) / (10.0 + t)
        if decay > max_decay:
            decay = max_decay
        ema -= (1-decay) * (ema - weights)
```

The settings here are all lifted from that SyntaxNet paper, and they've been unchanged for years in all spaCy models. I think this function is in Tensorflow too. The more recent SWA I tried from torchcontrib is described here: https://pytorch.org/blog/stochastic-weight-averaging-in-pytorch/ . I found this quite difficult to use, as the settings all depend on how many optimisation steps you expect to need, which depends on the batch size and learning rate. Hyper-parameter interactions like that make life really difficult.

With our EMA averaging, we do benefit from letting training run for longer. That's why I've added the cyclic learning rates as well. I didn't like letting the learning rate go to zero at an appointed time...I'd rather just let it run until it stops improving.