### PR TITLE
Pass nr_class as the number of classes

### DIFF
--- a/spacy_pytorch_transformers/model_registry.py
+++ b/spacy_pytorch_transformers/model_registry.py
@@ -93,7 +93,7 @@ def softmax_last_hidden(nr_class, *, exclusive_classes=True, **cfg):
     """
     width = cfg["token_vector_width"]
     return chain(
-        get_pytt_last_hidden, flatten_add_lengths, Pooling(mean_pool), Softmax(2, width)
+        get_pytt_last_hidden, flatten_add_lengths, Pooling(mean_pool), Softmax(nr_class, width)
     )
 
 


### PR DESCRIPTION
The architecture `softmax_last_hidden` does not consider the number of classes when building the final softmax layer. This PR fixes this issue. Together with commit 1adeac6, they would resolve issue #39.