### PR TITLE
fix: remove multiple call for `prepare_for_serialization`

### DIFF
--- a/spacy_pytorch_transformers/_tokenizers.py
+++ b/spacy_pytorch_transformers/_tokenizers.py
@@ -69,7 +69,6 @@ class SerializationMixin:
         return self.from_bytes(data, **kwargs)
 
     def to_disk(self, path, exclude=tuple(), **kwargs):
-        self.prepare_for_serialization()
         data = self.to_bytes(**kwargs)
         with (path / "pytt_tokenizer.msg").open("wb") as file_:
             file_.write(data)


### PR DESCRIPTION
I found unnecessary multiple call for `SerializationMixin.prepare_for_serialization`, and remove the one of them.